### PR TITLE
Fixed out of reach variable in array_map

### DIFF
--- a/post-type-gallery-modal.php
+++ b/post-type-gallery-modal.php
@@ -32,10 +32,11 @@ function ptgm_dynamic_render_callback($block_attributes)
 
 	$posts = get_posts($query);
 	$block_id = uniqid();
+	$size = $block_attributes['thumbnailSize'];
 
-	$posts_array = array_map(function ($post) use ($block_id) {
+	$posts_array = array_map(function ($post) use ($block_id, $size) {
 		$title = get_the_title($post);
-		$thumbnail = get_the_post_thumbnail($post->ID, $block_attributes['thumbnailSize'], array('alt' => $title, 'class' => 'wp-ptgm-img'));
+		$thumbnail = get_the_post_thumbnail($post->ID, $size, array('alt' => $title, 'class' => 'wp-ptgm-img'));
 		$featured_src = get_the_post_thumbnail_url($post->ID, 'large');
 
 		return sprintf(


### PR DESCRIPTION
The $block_attributes variable was out of reach in the array_map function line 39, fixed by setting the thumb size in a variable and passing that $variable to the array_map.

Also, I think we should start labeling the versions of the plugin for any changes we make to have a proper view when we use it if we're running the latest version ?